### PR TITLE
Ds update tasks

### DIFF
--- a/lib/gulp/karma.js
+++ b/lib/gulp/karma.js
@@ -1,11 +1,13 @@
 'use strict';
 
+var _ = require('lodash');
 var path = require('path');
 var karma = require('karma');
 
-module.exports = function(done) {
-  new karma.Server({
-    configFile: path.join(process.cwd(), 'karma.conf.js'),
-    singleRun: true
-  }, done).start();
+module.exports = function(done, options) {
+  new karma.Server(
+    _.merge({
+      configFile: path.join(process.cwd(), 'karma.conf.js'),
+      singleRun: true
+    }, options || {}), done).start();
 };

--- a/lib/gulp/sass.js
+++ b/lib/gulp/sass.js
@@ -7,16 +7,28 @@ var gulpif = require('gulp-if');
 var ignore = require('gulp-ignore');
 var newer = require('gulp-newer');
 var sass = require('gulp-sass');
+var path = require('path');
+var _ = require('lodash');
 
 var helpers = require('../helpers');
 
 var errcb = helpers.errcb;
 var isProd = helpers.isProd;
 
-module.exports = function(src, includePaths) {
-  return gulp.src(src)
-    .pipe(newer('dist/public/styles/client.css'))
-    .pipe(ignore.include('**/src/client/styles/application.sass'))
+module.exports = function(src, includePaths, _options) {
+  var options = _options || {};
+  var destDir = options.destDir || 'dist/public/styles';
+  var destFile = options.destFile || 'client.css';
+  var destPath = path.join(destDir, destFile);
+  var ignorePaths = options.ignore || ['**/src/client/styles/application.sass'];
+
+  var task = gulp.src(src).pipe(newer(destPath));
+
+  _.each(ignorePaths, function(ignorePath) {
+    task = task.pipe(ignore.include(ignorePath));
+  });
+
+  return task
     .pipe(sass({
       indentedSyntax: true,
       sourceComments: 'normal',
@@ -28,6 +40,6 @@ module.exports = function(src, includePaths) {
     .pipe(gulpif(isProd(), cssmin({
       keepBreaks: true
     })))
-    .pipe(concat('client.css'))
-    .pipe(gulp.dest('dist/public/styles/'));
+    .pipe(concat(destFile))
+    .pipe(gulp.dest(destDir));
 };


### PR DESCRIPTION
Adds options to sass and karma.

For karma, you can pass in an optional options has that is merged with the config passed to gulp-karma. See karma or gulp-karma for more information on what options can be passed in.

For sass, the following options are recognised:
  0. `destDir` - the destination directory for the compiled sass (defaults to `"dist/public/styles"`)
  0. `destFile` - the name of the resulting file (defaults to `"client.css"`)
  0. `ignore` - an array of paths to be ignored by sass (defaults to `"**/src/client/styles/application.sass"`)