### PR TITLE
Update sass.js

### DIFF
--- a/lib/gulp/sass.js
+++ b/lib/gulp/sass.js
@@ -5,7 +5,6 @@ var concat = require('gulp-concat');
 var cssmin = require('gulp-clean-css');
 var gulpif = require('gulp-if');
 var ignore = require('gulp-ignore');
-var newer = require('gulp-newer');
 var sass = require('gulp-sass');
 var path = require('path');
 
@@ -21,7 +20,7 @@ module.exports = function(src, includePaths, _options) {
   var destPath = path.join(destDir, destFile);
   var ignorePaths = options.ignore || ['**/src/client/styles/application.sass'];
 
-  var task = gulp.src(src).pipe(newer(destPath)).pipe(ignore.include(true, ignorePaths));
+  var task = gulp.src(src).pipe(ignore.include(true, ignorePaths));
 
   return task
     .pipe(sass({


### PR DESCRIPTION
This change removes the "newer" check from sass, since it ignores dependent files that are @imported from the main sass file.