### PR TITLE
Typescript Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ temp.js
 .cache-require-paths.json
 .coverrun
 .coverdata/
+.vs

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -5,6 +5,7 @@ var del = require('del');
 var _ = require('lodash');
 var serial = require('run-sequence');
 var path = require('path');
+var Promise = require('bluebird').Promise;
 
 const ts = require('gulp-typescript');
 const tsProject = ts.createProject('./tsconfig.json');
@@ -178,7 +179,7 @@ gulp.task('copy-test-files', () => {
   });
 });
 
-gulp.task('test-server', ['test-server-prereq', 'copy-test-files'], function (done) {
+gulp.task('test-server', ['test-server-prereq', 'copy-test-files'], function(done) {
   common.mocha(done,
     ['test/src/server/scripts/**/*.js', 'test/src/shared/scripts/**/*.js'],
     ['spec/server/helpers/index.js', 'spec/shared/**/*.spec.js', 'spec/server/**/*.spec.js']);

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -6,6 +6,9 @@ var _ = require('lodash');
 var serial = require('run-sequence');
 var path = require('path');
 
+const ts = require('gulp-typescript');
+const tsProject = ts.createProject('./tsconfig.json');
+
 var common = {
   awsdeployeb: require('./aws-deploy-eb'),
   bower: require('./bower'),
@@ -152,10 +155,33 @@ gulp.task('test-client', ['test-client-prereq'], function(done) {
 
 gulp.task('test-server-prereq', ['jslint-server-spec', 'jslint-shared-spec']);
 
-gulp.task('test-server', ['test-server-prereq'], function(done) {
-  return common.mocha(done, ['src/server/scripts/**/*.js', 'src/shared/scripts/**/*.js'], [
-    'spec/server/helpers/index.js', 'spec/shared/**/*.spec.js', 'spec/server/**/*.spec.js'
-  ]);
+gulp.task('copy-test-files', () => {
+  const tsResult = gulp.src('src/server/scripts/**/*.ts', { base: '.' })
+    .pipe(tsProject())
+    .js
+    .pipe(gulp.dest('test'));
+
+  return new Promise(resolver => {
+    common.copy('test/src/shared', 'src/shared/**/*.*')
+      .on('finish', () => {
+        common.copy('test/src/cwIntegration', 'src/cwIntegration/**/*.*')
+          .on('finish', () => {
+            common.copy('test/src/database', 'src/database/**/*.*')
+              .on('finish', () => {
+                common.copy('test/src/server', 'src/server/**/*.*')
+                  .on('finish', () => {
+                    resolver();
+                  });
+              });
+          });
+      });
+  });
+});
+
+gulp.task('test-server', ['test-server-prereq', 'copy-test-files'], function (done) {
+  common.mocha(done,
+    ['test/src/server/scripts/**/*.js', 'test/src/shared/scripts/**/*.js'],
+    ['spec/server/helpers/index.js', 'spec/shared/**/*.spec.js', 'spec/server/**/*.spec.js']);
 });
 
 gulp.task('test', function(done) {

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -156,7 +156,7 @@ gulp.task('test-client', ['test-client-prereq'], function(done) {
 gulp.task('test-server-prereq', ['jslint-server-spec', 'jslint-shared-spec']);
 
 gulp.task('copy-test-files', () => {
-  const tsResult = gulp.src('src/server/scripts/**/*.ts', { base: '.' })
+  gulp.src('src/server/scripts/**/*.ts', { base: '.' })
     .pipe(tsProject())
     .js
     .pipe(gulp.dest('test'));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "gulp-typescript": "^4.0.1",
     "karma-chai-plugins": "^0.7.0",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma-chai-plugins": "^0.7.0",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.0",
-    "phantomjs-prebuilt": "^2.1.7"
+    "phantomjs-prebuilt": "^2.1.7",
+    "typescript": "^2.7.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "sourceMap": false,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "target": "es5",
+    "baseUrl": "/",
+    "listEmittedFiles": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ]
+  },
+  "include": ["lib/**/*.ts"]
+}


### PR DESCRIPTION
include typescript for builds
moved all tests to deploy to temp folder in order to merge ts-generated files into source folder so tests will succeed