### PR TITLE
Fix paths for exec scripts

### DIFF
--- a/tasks/exec/exec-aws-deploy-eb.js
+++ b/tasks/exec/exec-aws-deploy-eb.js
@@ -5,7 +5,7 @@ const argv = require('yargs').argv;
 const exec = require('./exec-wrapper');
 
 const task = (cb) => {
-  const bin = path.join(__dirname, '../bin/aws-deploy-eb.sh');
+  const bin = path.join(__dirname, '../../bin/aws-deploy-eb.sh');
   const cmd = ['bash', bin, argv.env, argv.cname].join(' ');
   exec(cmd, cb);
 };

--- a/tasks/exec/exec-github-master.js
+++ b/tasks/exec/exec-github-master.js
@@ -4,7 +4,7 @@ const path = require('path');
 const exec = require('./exec-wrapper');
 
 const task = (cb) => {
-  const bin = path.join(__dirname, '../bin/github-master.sh');
+  const bin = path.join(__dirname, '../../bin/github-master.sh');
   const cmd = ['bash', bin].join(' ');
 
   exec(cmd, cb);

--- a/tasks/exec/exec-pivotal.js
+++ b/tasks/exec/exec-pivotal.js
@@ -4,7 +4,7 @@ const path = require('path');
 const exec = require('./exec-wrapper');
 
 const task = (cb) => {
-  var bin = path.join(__dirname, '../bin/pivotal.sh');
+  var bin = path.join(__dirname, '../../bin/pivotal.sh');
   var cmd = ['bash', bin].join(' ');
   exec(cmd, cb);
 };


### PR DESCRIPTION
Scripts were scoped to look in `../bin` but due to new folder structure being `/tasks/exec/` instead of `/tasks/` the doesn't resolve. Changed path to `../../bin/` to fix.