### PR TITLE
Update Babel Configuration

### DIFF
--- a/tasks/base/jsangular.js
+++ b/tasks/base/jsangular.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const path = require('path');
-
 const gulp = require('gulp');
 const babel = require('gulp-babel');
 const concat = require('gulp-concat');
@@ -23,7 +21,7 @@ const task = (file, dest, src) => {
     .pipe(eslint.format())
     .pipe(gulpif(!isProduction(), sourcemaps.init()))
     .pipe(babel({
-      babelrc: path.join(process.cwd(), '.babelrc')
+      babelrc: true
     }))
     .on('error', errcb)
     .pipe(gulpif(isProduction(), annotate()))

--- a/tasks/base/jsnode.js
+++ b/tasks/base/jsnode.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const gulp = require('gulp');
 const babel = require('gulp-babel');
 const eslint = require('gulp-eslint');
@@ -18,7 +17,7 @@ const task = (dest, src) => {
     .pipe(eslint.format())
     .pipe(gulpif(!isProduction(), sourcemaps.init()))
     .pipe(babel({
-      babelrc: path.join(process.cwd(), '.babelrc')
+      babelrc: true
     }))
     .on('error', errcb)
     .pipe(gulpif(!isProduction(), sourcemaps.write('.', {


### PR DESCRIPTION
## Changes

- `babelrc: 'pathToRc'` changed to `babelrc: true`

## Rationale

- `babelrc` no longer supports specifying the path. (in 7.x atleast, unknown when it stopped)
- `babelrc` now is automatically found by babel. If we were expecting it to be in a non-standard place we will need to rectify it.