### PR TITLE
Update Build Image, Correct Coverage Task Description

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,15 +10,10 @@ jobs:
       NODE_ENV: test
       TZ: Africa/Johannesburg
     docker:
-    # - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-    #   command: /sbin/init
-    - image: circleci/node:14-stretch-browsers-legacy
+    - image: cimg/node:16.13.2-browsers
     steps:
     - checkout
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    # - run:
-    #     working_directory: ~/CQSCloud/common-gulp
-    #     command: nvm install 8.9.1 && nvm alias default 8.9.1
     - restore_cache:
         keys:
         - v1-dep-{{ .Branch }}-
@@ -56,14 +51,9 @@ jobs:
       NODE_ENV: test
       TZ: Africa/Johannesburg
     docker:
-    # - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-    #   command: /sbin/init
-    - image: circleci/node:14-stretch-browsers-legacy
+    - image: cimg/node:16.13.2-browsers
     steps:
     - checkout
-    # - run:
-    #     working_directory: ~/CQSCloud/common-gulp
-    #     command: nvm install 8.9.1 && nvm alias default 8.9.1
     - restore_cache:
         keys:
         - v1-dep-{{ .Branch }}-

--- a/tasks/base/coverage.js
+++ b/tasks/base/coverage.js
@@ -14,6 +14,6 @@ const task = () => {
     .pipe(gulp.dest('coverage/'));
 };
 task.displayName = 'coverage';
-task.description = 'Generate Coverage and merge to coverage/ directory';
+task.description = 'Merge Coverage to coverage/ directory';
 
 module.exports = task;


### PR DESCRIPTION
## Changes

- Use the same node 16 image `common-cloud` uses.
- Use `cimg/` instead of `circleci/` repo as per recommendations from *CircleCi*.
- Rename coverage task description to more accurately describe it's function. It does not generate any coverage, that is the job of `nyc`.